### PR TITLE
add high-order purify function for stateless components

### DIFF
--- a/src/high-order.js
+++ b/src/high-order.js
@@ -1,0 +1,31 @@
+import shallowEqual from './shallowEqual';
+
+export default function pureStateless(statelessComponent) {
+
+    let lastProps, lastContext,
+        savedResult, savedException;
+
+    return function (props, context) {
+        let shouldUpdate = !shallowEqual(props, lastProps) || !shallowEqual(context, lastContext);
+
+        if (shouldUpdate) {
+          lastProps = props;
+          lastContext = context;
+
+          savedResult = undefined;
+          savedException = undefined;
+
+          try {
+            savedResult = statelessComponent.apply(this, arguments);
+          } catch(e) {
+            savedException = e;
+          }
+        }
+
+        if (savedException !== undefined) {
+          throw savedException;
+        }
+
+        return savedResult;
+    };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ export shallowEqual from './shallowEqual';
 export shouldPureComponentUpdate from './function';
 export PureComponent from './component';
 export PureMixin from './mixin';
+export pureStateless from './high-order';


### PR DESCRIPTION
Adding `pureStateless` function to purify stateless React components:

``` js
import pureStateless from 'react-pure-render/high-order';

let Title = (props, context) => <div onClick={props.onClick}>{props.title}</div>

export default pureStateless(Title);
```
