### PR TITLE
Update project to use babel 6 and support jsnext

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,17 @@
 {
-  "stage": 0,
-  "loose": ["es6.modules", "es6.classes"]
+  "plugins": [
+    ["transform-es2015-classes", { "loose": true }],
+    "check-es2015-constants",
+    "transform-es2015-block-scoping"
+  ],
+  "env": {
+    "commonjs": {
+      "plugins": [
+        ["transform-es2015-modules-commonjs", { "loose": true }]
+      ]
+    },
+    "es": {
+      "plugins": []
+    }
+  }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig helps developers define and maintain
+# consistent coding styles between different editors and IDEs.
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,3 @@
 {
-  "env": {
-    "browser": true,
-    "node": true,
-    "mocha": true
-  },
-  "parser": "babel-eslint",
-  "rules": {
-    "quotes": [2, "single"],
-    "eol-last": [0],
-    "no-mixed-requires": [0],
-    "no-underscore-dangle": [0],
-    "consistent-return": [0],
-    "strict": [0, "never"]
-  }
+  "extends": "rackt"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@ node_modules
 .DS_Store
 
 # Build products
-component.js
-function.js
-index.js
-mixin.js
-shallowEqual.js
+es
+lib

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-src
-scripts

--- a/package.json
+++ b/package.json
@@ -2,14 +2,24 @@
   "name": "react-pure-render",
   "version": "1.0.2",
   "description": "A function, a component and a mixin for React pure rendering",
-  "main": "index.js",
+  "main": "lib/index.js",
+  "jsnext:main": "es/index.js",
+  "files": [
+    "es",
+    "lib",
+    "src"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/gaearon/react-pure-render.git"
   },
   "scripts": {
-    "build": "./scripts/build",
-    "prepublish": "npm run build"
+    "build": "npm run build:commonjs && npm run build:es",
+    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
+    "clean": "rimraf lib es",
+    "lint": "eslint src",
+    "prepublish": "npm run clean && npm run lint && npm run build"
   },
   "keywords": [
     "react",
@@ -26,8 +36,15 @@
   },
   "homepage": "https://github.com/gaearon/react-pure-render",
   "devDependencies": {
-    "babel": "^5.2.9",
-    "babel-eslint": "^3.0.1",
-    "eslint": "^0.20.0"
+    "babel-cli": "^6.5.1",
+    "babel-eslint": "^5.0.0",
+    "babel-plugin-check-es2015-constants": "^6.5.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.5.0",
+    "babel-plugin-transform-es2015-classes": "^6.5.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.5.2",
+    "cross-env": "^1.0.7",
+    "eslint": "^2.2.0",
+    "eslint-config-rackt": "^1.1.1",
+    "rimraf": "^2.5.2"
   }
 }

--- a/scripts/build
+++ b/scripts/build
@@ -1,2 +1,0 @@
-#!/bin/sh
-./node_modules/.bin/babel src --out-dir .

--- a/src/component.js
+++ b/src/component.js
@@ -1,5 +1,5 @@
-import shouldPureComponentUpdate from './function';
-import { Component } from 'react';
+import shouldPureComponentUpdate from './function'
+import { Component } from 'react'
 
 export default class PureComponent extends Component {}
-PureComponent.prototype.shouldComponentUpdate = shouldPureComponentUpdate;
+PureComponent.prototype.shouldComponentUpdate = shouldPureComponentUpdate

--- a/src/function.js
+++ b/src/function.js
@@ -1,6 +1,6 @@
-import shallowEqual from './shallowEqual';
+import shallowEqual from './shallowEqual'
 
 export default function shouldPureComponentUpdate(nextProps, nextState) {
   return !shallowEqual(this.props, nextProps) ||
-         !shallowEqual(this.state, nextState);
+         !shallowEqual(this.state, nextState)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export shallowEqual from './shallowEqual';
-export shouldPureComponentUpdate from './function';
-export PureComponent from './component';
-export PureMixin from './mixin';
+export { default as shallowEqual } from './shallowEqual'
+export { default as shouldPureComponentUpdate } from './function'
+export { default as PureComponent } from './component'
+export { default as PureMixin } from './mixin'

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,5 +1,5 @@
-import shouldPureComponentUpdate from './function';
+import shouldPureComponentUpdate from './function'
 
 export default {
   shouldComponentUpdate: shouldPureComponentUpdate
-};
+}

--- a/src/shallowEqual.js
+++ b/src/shallowEqual.js
@@ -1,27 +1,27 @@
 export default function shallowEqual(objA, objB) {
   if (objA === objB) {
-    return true;
+    return true
   }
 
   if (typeof objA !== 'object' || objA === null ||
       typeof objB !== 'object' || objB === null) {
-    return false;
+    return false
   }
 
-  var keysA = Object.keys(objA);
-  var keysB = Object.keys(objB);
+  const keysA = Object.keys(objA)
+  const keysB = Object.keys(objB)
 
   if (keysA.length !== keysB.length) {
-    return false;
+    return false
   }
 
   // Test for A's keys different from B.
-  var bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
-  for (var i = 0; i < keysA.length; i++) {
+  const bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB)
+  for (let i = 0; i < keysA.length; i++) {
     if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
-      return false;
+      return false
     }
   }
 
-  return true;
+  return true
 }


### PR DESCRIPTION
- Added support for `jsnext:main` in `package.json`
- Added `.editorconfig` file
- Upgraded to babel 6
- Updated linting to use rackt

I looked at the redux repo and based this change mostly on what I saw there. The change should be backwards compatible.

The only notable change is the removal of the experimental export-from syntax changes, because I'm not sure what plugin that requires.
